### PR TITLE
Crash fix and other improvements

### DIFF
--- a/RFMarkdownTextView.podspec
+++ b/RFMarkdownTextView.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Rudd Fawcett' => 'rudd.fawcett@gmail.com' }
   s.social_media_url = 'https://twitter.com/ruddfawcett'
   s.platform     = :ios, '7.0'
-  s.source       = { :git => 'https://github.com/ruddfawcett/RFMarkdownTextView.git', :tag => 'v1.4' }
+  s.source       = { :git => 'https://github.com/landakram/RFMarkdownTextView.git', :tag => 'v1.5' }
   s.source_files  = 'RFMarkdownTextView/*.{h,m}'
   s.requires_arc = true
   s.dependency 'RFKeyboardToolbar', '~> 1.3'

--- a/RFMarkdownTextView.podspec
+++ b/RFMarkdownTextView.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Rudd Fawcett' => 'rudd.fawcett@gmail.com' }
   s.social_media_url = 'https://twitter.com/ruddfawcett'
   s.platform     = :ios, '7.0'
-  s.source       = { :git => 'https://github.com/landakram/RFMarkdownTextView.git', :tag => 'v1.5' }
+  s.source       = { :git => 'https://github.com/landakram/RFMarkdownTextView.git', :tag => 'v1.5.1' }
   s.source_files  = 'RFMarkdownTextView/*.{h,m}'
   s.requires_arc = true
   s.dependency 'RFKeyboardToolbar', '~> 1.3'

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
@@ -2,8 +2,24 @@
 //  RFMarkdownSyntaxStorage.h
 //  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/6/13.
-//  Copyright (c) 2013 Rudd Fawcett. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import <UIKit/UIKit.h>

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
@@ -11,5 +11,6 @@
 @interface RFMarkdownSyntaxStorage : NSTextStorage
 
 - (void)update;
+- (void)update:(NSRange)range;
 
 @end

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -59,6 +59,14 @@
     [self endEditing];
 }
 
+- (void)addAttributes:(NSDictionary *)attrs range:(NSRange)range {
+    [self beginEditing];
+    
+    [super addAttributes:attrs range:range];
+    
+    [self endEditing];
+}
+
 - (void)processEditing {
     [self performReplacementsForRange:[self editedRange]];
     [super processEditing];
@@ -119,12 +127,16 @@
                       };
 }
 
-- (void)update {
+- (void)update:(NSRange)range {
     [self createHighlightPatterns];
     
     [self addAttributes:_bodyFont range:NSMakeRange(0, self.length)];
     
-    [self applyStylesToRange:NSMakeRange(0, self.length)];
+    [self applyStylesToRange:[[self.attributedString mutableString] lineRangeForRange:range]];
+}
+
+- (void)update {
+    [self update:NSMakeRange(0, self.length)];
 }
 
 - (void)applyStylesToRange:(NSRange)searchRange {

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -8,6 +8,9 @@
 
 #import "RFMarkdownSyntaxStorage.h"
 
+#define FONT_SIZE 14
+#define BODY_FONT [UIFont fontWithName:@"Menlo" size:FONT_SIZE]
+
 @interface RFMarkdownSyntaxStorage ()
 
 @property (nonatomic, strong) NSMutableAttributedString *attributedString;
@@ -21,7 +24,8 @@
 
 - (id)init {
     if (self = [super init]) {
-        _bodyFont = @{NSFontAttributeName:[UIFont systemFontOfSize:12], NSForegroundColorAttributeName:[UIColor blackColor],NSUnderlineStyleAttributeName:[NSNumber numberWithInt:NSUnderlineStyleNone]};
+        
+        _bodyFont = @{NSFontAttributeName:BODY_FONT, NSForegroundColorAttributeName:[UIColor blackColor],NSUnderlineStyleAttributeName:[NSNumber numberWithInt:NSUnderlineStyleNone]};
         _attributedString = [NSMutableAttributedString new];
         
         [self createHighlightPatterns];
@@ -68,11 +72,17 @@
 }
 
 - (void)createHighlightPatterns {
-    NSDictionary *boldAttributes = @{NSFontAttributeName:[UIFont boldSystemFontOfSize:12]};
-    NSDictionary *italicAttributes = @{NSFontAttributeName:[UIFont italicSystemFontOfSize:12]};
-    NSDictionary *boldItalicAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"HelveticaNeue-BoldItalic" size:11.5]};
+    NSDictionary *boldAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-Bold" size:FONT_SIZE]};
+    NSDictionary *italicAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-Italic" size:FONT_SIZE]};
+    NSDictionary *boldItalicAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-BoldItalic" size:FONT_SIZE]};
     
     NSDictionary *codeAttributes = @{NSForegroundColorAttributeName:[UIColor grayColor]};
+    
+    NSDictionary *headerOneAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-Bold" size:FONT_SIZE], NSUnderlineStyleAttributeName:[NSNumber numberWithInt:NSUnderlineStyleSingle], NSUnderlineColorAttributeName:[UIColor colorWithWhite:0.933 alpha:1.0]};
+    NSDictionary *headerTwoAttributes = headerOneAttributes;
+    NSDictionary *headerThreeAttributes = headerOneAttributes;
+    
+    NSDictionary *strikethroughAttributes = @{NSFontAttributeName:BODY_FONT, NSStrikethroughStyleAttributeName:@(NSUnderlineStyleSingle)};
     
     /*
      NSDictionary *headerOneAttributes = @{NSFontAttributeName:[UIFont boldSystemFontOfSize:14]};
@@ -95,12 +105,17 @@
     
     _attributeDictionary = @{
                       @"[a-zA-Z0-9\t\n ./<>?;:\\\"'`!@#$%^&*()[]{}_+=|\\-]":_bodyFont,
+                      @"~~(\\*(\\w+(\\s\\w+)*)\\*)~~":strikethroughAttributes,
                       @"\\**(?:^|[^*])(\\*\\*(\\w+(\\s\\w+)*)\\*\\*)":boldAttributes,
                       @"\\**(?:^|[^*])(\\*(\\w+(\\s\\w+)*)\\*)":italicAttributes,
                       @"(\\*\\*\\*\\w+(\\s\\w+)*\\*\\*\\*)":boldItalicAttributes,
                       @"(`\\w+(\\s\\w+)*`)":codeAttributes,
                       @"(```\n([\\s\n\\d\\w[/[\\.,-\\/#!?@$%\\^&\\*;:|{}<>+=\\-'_~()\\\"\\[\\]\\\\]/]]*)\n```)":codeAttributes,
-                      @"(\\[\\w+(\\s\\w+)*\\]\\(\\w+\\w[/[\\.,-\\/#!?@$%\\^&\\*;:|{}<>+=\\-'_~()\\\"\\[\\]\\\\]/ \\w+]*\\))":linkAttributes
+                      @"(\\[\\w+(\\s\\w+)*\\]\\(\\w+\\w[/[\\.,-\\/#!?@$%\\^&\\*;:|{}<>+=\\-'_~()\\\"\\[\\]\\\\]/ \\w+]*\\))":linkAttributes,
+                      @"(\\[\\[\\w+(\\s\\w+)*\\]\\])":linkAttributes,
+                      @"(\\#\\s?\\w*(\\s\\w+)*\\n)":headerOneAttributes,
+                      @"(\\##\\s?\\w*(\\s\\w+)*\\n)":headerTwoAttributes,
+                      @"(\\###\\s?\\w*(\\s\\w+)*\\n)":headerThreeAttributes
                       };
 }
 

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -1,10 +1,24 @@
 //
 //  RFMarkdownSyntaxStorage.m
-//  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/6/13.
-//  Copyright (c) 2013 Rudd Fawcett. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
 //
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "RFMarkdownSyntaxStorage.h"
 
@@ -158,5 +172,8 @@
         }];
     }
 }
+
+#pragma mark Property Access
+
 
 @end

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -105,7 +105,7 @@
     
     _attributeDictionary = @{
                       @"[a-zA-Z0-9\t\n ./<>?;:\\\"'`!@#$%^&*()[]{}_+=|\\-]":_bodyFont,
-                      @"~~(\\*(\\w+(\\s\\w+)*)\\*)~~":strikethroughAttributes,
+                      @"~~(\\w+(\\s\\w+)*)~~":strikethroughAttributes,
                       @"\\**(?:^|[^*])(\\*\\*(\\w+(\\s\\w+)*)\\*\\*)":boldAttributes,
                       @"\\**(?:^|[^*])(\\*(\\w+(\\s\\w+)*)\\*)":italicAttributes,
                       @"(\\*\\*\\*\\w+(\\s\\w+)*\\*\\*\\*)":boldItalicAttributes,

--- a/RFMarkdownTextView/RFMarkdownTextView.h
+++ b/RFMarkdownTextView/RFMarkdownTextView.h
@@ -2,8 +2,24 @@
 //  RFMarkdownTextView.h
 //  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/1/13.
-//  Copyright (c) 2013 Rudd Fawcett. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import <UIKit/UIKit.h>

--- a/RFMarkdownTextView/RFMarkdownTextView.h
+++ b/RFMarkdownTextView/RFMarkdownTextView.h
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 @import RFKeyboardToolbar;
-#import "RFMarkdownSyntaxStorage.h"
 
 @class RFMarkdownTextView;
 

--- a/RFMarkdownTextView/RFMarkdownTextView.h
+++ b/RFMarkdownTextView/RFMarkdownTextView.h
@@ -7,10 +7,19 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "RFKeyboardToolbar.h"
-#import "RFToolbarButton.h"
+@import RFKeyboardToolbar;
 #import "RFMarkdownSyntaxStorage.h"
 
+@class RFMarkdownTextView;
+
+typedef void (^ImageBlock)(NSString *);
+
+@protocol ImagePickerDelegate <NSObject>
+- (void)textViewWantsImage:(RFMarkdownTextView *)textView completion:(ImageBlock)imageBlock;
+@end
+
 @interface RFMarkdownTextView : UITextView <UITextViewDelegate>
+
+@property (nonatomic, weak) id<ImagePickerDelegate> imagePickerDelegate;
 
 @end

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -156,12 +156,18 @@
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
     if ([text isEqualToString:@"\n"]) {
+        // Matches " *" and " - [ ]"
         NSString *pattern = @" *(\\*|- \\[( |x)\\]) ";
         NSError  *error = nil;
         NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
         
         if (range.location > 0) {
             NSRange oldRange = NSMakeRange(MAX(0, range.location - 1), range.length);
+            
+            // Don't match the previous line if the user is making a newline on an empty line
+            if ([[self.text substringWithRange:NSMakeRange(oldRange.location, 1)] isEqualToString:@"\n"]) {
+                return YES;
+            }
             NSRange previousLineRange = [self.text lineRangeForRange:oldRange];
             
             NSArray *matches = [regex matchesInString:self.text options:0 range: previousLineRange];

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -7,6 +7,7 @@
 //
 
 #import "RFMarkdownTextView.h"
+#import "RFMarkdownSyntaxStorage.h"
 
 @interface RFMarkdownTextView ()
 

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -183,7 +183,7 @@
 }
 
 - (void)textViewDidChange:(UITextView *)textView {
-    [_syntaxStorage update];
+    [_syntaxStorage update:self.selectedRange];
 }
 
 @end

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -11,10 +11,13 @@
 @interface RFMarkdownTextView ()
 
 @property (strong,nonatomic) RFMarkdownSyntaxStorage *syntaxStorage;
+@property (nonatomic, assign) UIEdgeInsets priorInset;
 
 @end
 
 @implementation RFMarkdownTextView
+@synthesize imagePickerDelegate;
+@synthesize priorInset;
 
 - (id)initWithFrame:(CGRect)frame {
     NSAttributedString *attrString = [[NSAttributedString alloc] initWithString:@"" attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:12]}];
@@ -36,44 +39,68 @@
         self.delegate = self;
         self.inputAccessoryView = [RFKeyboardToolbar toolbarWithButtons:[self buttons]];
     }
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(keyboardWillShow:)
+                                                 name:UIKeyboardWillShowNotification object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(keyboardWillBeHidden:)
+                                                 name:UIKeyboardWillHideNotification object:nil];
+    
     return self;
 }
 
+- (void)keyboardWillShow:(NSNotification*)notification {
+    CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
+    if (CGRectIsEmpty(keyboardRect)) {
+        return;
+    }
+    
+    self.priorInset = self.contentInset;
+    
+    self.contentInset = UIEdgeInsetsMake(self.contentInset.top, self.contentInset.left, keyboardRect.size.height, self.contentInset.right);
+    self.scrollIndicatorInsets = self.contentInset;
+}
 
+- (void)keyboardWillBeHidden:(NSNotification*)notification {
+    self.contentInset = priorInset;
+    self.scrollIndicatorInsets = self.contentInset;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 
 - (NSArray *)buttons {
-    return @[[self createButtonWithTitle:@"#" andEventHandler:^{ [self insertText:@"#"]; }],
-             [self createButtonWithTitle:@"*" andEventHandler:^{ [self insertText:@"*"]; }],
-             [self createButtonWithTitle:@"_" andEventHandler:^{ [self insertText:@"_"]; }],
+    return @[
+             [self createButtonWithTitle:@"#" andEventHandler:^{ [self insertText:@"#"]; }],
+             [self createButtonWithTitle:@"*" andEventHandler:^{
+                 [self insertText:@"*"];
+             }],
+             [self createButtonWithTitle:@"->|" andEventHandler:^{ [self insertText:@"  "]; }],
+             [self createButtonWithTitle:@"[[" andEventHandler:^{
+                 NSRange selectionRange = self.selectedRange;
+                 selectionRange.location += 2;
+                 [self insertText:@"[[]]"];
+                 [self setSelectionRange:selectionRange];
+             }],
              [self createButtonWithTitle:@"`" andEventHandler:^{ [self insertText:@"`"]; }],
-             [self createButtonWithTitle:@"@" andEventHandler:^{ [self insertText:@"@"]; }],
+             [self createButtonWithTitle:@"Photo" andEventHandler:^{
+                 ImageBlock block = ^(NSString *imagePath) {
+                     NSRange selectionRange = self.selectedRange;
+                     selectionRange.location += 2;
+                     [self insertText:[NSString stringWithFormat:@"![](img/%@)", imagePath]];
+                     [self setSelectionRange:self.selectedRange];
+                 };
+                 [imagePickerDelegate textViewWantsImage:self completion:block];
+             }],
              [self createButtonWithTitle:@"Link" andEventHandler:^{
                  NSRange selectionRange = self.selectedRange;
                  selectionRange.location += 1;
                  [self insertText:@"[]()"];
                  [self setSelectionRange:selectionRange];
                  
-             }],
-             [self createButtonWithTitle:@"Codeblock" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += self.text.length == 0 ? 3 : 4;
-                 
-                 [self insertText: self.text.length == 0 ? @"```\n```" : @"\n```\n```"];
-                 [self setSelectionRange:selectionRange];
-             }],
-             [self createButtonWithTitle:@"Image" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += 2;
-                 
-                 [self insertText:@"![]()"];
-                 [self setSelectionRange:self.selectedRange];
-             }],
-             [self createButtonWithTitle:@"Task" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += 7;
-                 
-                 [self insertText:self.text.length == 0 ? @"- [ ] " : @"\n- [ ] "];
-                 [self setSelectionRange:selectionRange];
              }],
              [self createButtonWithTitle:@"Quote" andEventHandler:^{
                  NSRange selectionRange = self.selectedRange;

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -72,20 +72,51 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+- (void)wrapSelectedRangeWithString:(NSString *)string {
+    [self wrapSelectedRangeWithStartString:string endString:string];
+}
+
+- (void)wrapSelectedRangeWithStartString:(NSString *)startString endString:(NSString *)endString {
+    NSUInteger length = self.selectedRange.length;
+    NSUInteger location = self.selectedRange.location;
+    [self setSelectionRange:NSMakeRange(self.selectedRange.location, 0)];
+    [self insertText:startString];
+    NSUInteger endLocation = self.selectedRange.location + length;
+    [self setSelectionRange:NSMakeRange(endLocation, 0)];
+    [self insertText:endString];
+    [self setSelectionRange:NSMakeRange(location + startString.length, length)];
+}
+
 - (NSArray *)buttons {
     return @[
              [self createButtonWithTitle:@"#" andEventHandler:^{ [self insertText:@"#"]; }],
              [self createButtonWithTitle:@"*" andEventHandler:^{
-                 [self insertText:@"*"];
+                 if (self.selectedRange.length > 0) {
+                     [self wrapSelectedRangeWithString:@"*"];
+                 } else {
+                     [self insertText:@"*"];
+                 }
              }],
              [self createButtonWithTitle:@"->|" andEventHandler:^{ [self insertText:@"  "]; }],
              [self createButtonWithTitle:@"[[" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += 2;
-                 [self insertText:@"[[]]"];
-                 [self setSelectionRange:selectionRange];
+                 if (self.selectedRange.length > 0) {
+                     [self wrapSelectedRangeWithStartString:@"[[" endString:@"]]"];
+                     NSString *linkName = [self textInRange:self.selectedTextRange];
+                     [self replaceRange:self.selectedTextRange withText:[linkName capitalizedString]];
+                 } else {
+                     NSRange selectionRange = self.selectedRange;
+                     selectionRange.location += 2;
+                     [self insertText:@"[[]]"];
+                     [self setSelectionRange:selectionRange];
+                 }
              }],
-             [self createButtonWithTitle:@"`" andEventHandler:^{ [self insertText:@"`"]; }],
+             [self createButtonWithTitle:@"`" andEventHandler:^{
+                 if (self.selectedRange.length > 0) {
+                     [self wrapSelectedRangeWithString:@"`"];
+                 } else {
+                     [self insertText:@"`"];
+                 }
+             }],
              [self createButtonWithTitle:@"Photo" andEventHandler:^{
                  ImageBlock block = ^(NSString *imagePath) {
                      NSRange selectionRange = self.selectedRange;
@@ -121,6 +152,28 @@
 
 - (RFToolbarButton *)createButtonWithTitle:(NSString*)title andEventHandler:(void(^)())handler {
     return [RFToolbarButton buttonWithTitle:title andEventHandler:handler forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
+    if ([text isEqualToString:@"\n"]) {
+        NSString *pattern = @" *(\\*|- \\[( |x)\\]) ";
+        NSError  *error = nil;
+        NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
+        
+        if (range.location > 0) {
+            NSRange oldRange = NSMakeRange(MAX(0, range.location - 1), range.length);
+            NSRange previousLineRange = [self.text lineRangeForRange:oldRange];
+            
+            NSArray *matches = [regex matchesInString:self.text options:0 range: previousLineRange];
+            
+            if (matches.count > 0) {
+                NSString *previousPrefix = [self.text substringWithRange:[matches[0] rangeAtIndex:0]];
+                [self insertText:[NSString stringWithFormat:@"\n%@", previousPrefix]];
+                return NO;
+            }
+        }
+    }
+    return YES;
 }
 
 - (void)textViewDidChange:(UITextView *)textView {

--- a/RFMarkdownTextView/RFMarkdownToolbarButton.h
+++ b/RFMarkdownTextView/RFMarkdownToolbarButton.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Rex Finn. All rights reserved.
 //
 
-#import "RFToolbarButton.h"
+@import RFKeyboardToolbar;
 
 @interface RFMarkdownToolbarButton : RFToolbarButton
 

--- a/RFMarkdownTextView/RFMarkdownToolbarButton.m
+++ b/RFMarkdownTextView/RFMarkdownToolbarButton.m
@@ -2,8 +2,24 @@
 //  RFMarkdownToolbarButton.m
 //  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/19/13.
-//  Copyright (c) 2013 Rex Finn. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import "RFMarkdownToolbarButton.h"


### PR DESCRIPTION
 - Fixed crashing when the text view's contents is set programmatically.
 - Applied the MIT license to source files
 - Use the system font's size as a base for the text view's font
   - next-up is to respond to text style changes
 - Cache regex objects to improve performance a bit
