### PR TITLE
Crash fix and other improvements

### DIFF
--- a/RFMarkdownTextView.podspec
+++ b/RFMarkdownTextView.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Rudd Fawcett' => 'rudd.fawcett@gmail.com' }
   s.social_media_url = 'https://twitter.com/ruddfawcett'
   s.platform     = :ios, '7.0'
-  s.source       = { :git => 'https://github.com/ruddfawcett/RFMarkdownTextView.git', :tag => 'v1.4' }
+  s.source       = { :git => 'https://github.com/landakram/RFMarkdownTextView.git', :tag => 'v1.5' }
   s.source_files  = 'RFMarkdownTextView/*.{h,m}'
   s.requires_arc = true
   s.dependency 'RFKeyboardToolbar', '~> 1.3'

--- a/RFMarkdownTextView.podspec
+++ b/RFMarkdownTextView.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Rudd Fawcett' => 'rudd.fawcett@gmail.com' }
   s.social_media_url = 'https://twitter.com/ruddfawcett'
   s.platform     = :ios, '7.0'
-  s.source       = { :git => 'https://github.com/landakram/RFMarkdownTextView.git', :tag => 'v1.5' }
+  s.source       = { :git => 'https://github.com/landakram/RFMarkdownTextView.git', :tag => 'v1.5.1' }
   s.source_files  = 'RFMarkdownTextView/*.{h,m}'
   s.requires_arc = true
   s.dependency 'RFKeyboardToolbar', '~> 1.3'

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
@@ -26,7 +26,5 @@
 
 @interface RFMarkdownSyntaxStorage : NSTextStorage
 
-- (void)update;
-- (void)update:(NSRange)range;
 
 @end

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
@@ -2,8 +2,24 @@
 //  RFMarkdownSyntaxStorage.h
 //  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/6/13.
-//  Copyright (c) 2013 Rudd Fawcett. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import <UIKit/UIKit.h>

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.h
@@ -11,5 +11,6 @@
 @interface RFMarkdownSyntaxStorage : NSTextStorage
 
 - (void)update;
+- (void)update:(NSRange)range;
 
 @end

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -76,8 +76,7 @@
 
 - (void)performReplacementsForRange:(NSRange)changedRange {
     NSString* backingString = [_backingStore string];
-    NSRange extendedRange = NSUnionRange(changedRange, [backingString lineRangeForRange:NSMakeRange(changedRange.location, 0)]);
-    extendedRange = NSUnionRange(changedRange, [backingString lineRangeForRange:NSMakeRange(NSMaxRange(changedRange), 0)]);
+    NSRange extendedRange = extendedRange = NSUnionRange(changedRange, [backingString lineRangeForRange:NSMakeRange(NSMaxRange(changedRange), 0)]);
     
     [self applyStylesToRange:extendedRange];
 }

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -69,14 +69,6 @@
     [self endEditing];
 }
 
-- (void)addAttributes:(NSDictionary *)attrs range:(NSRange)range {
-    [self beginEditing];
-    
-    [super addAttributes:attrs range:range];
-    
-    [self endEditing];
-}
-
 - (void)processEditing {
     [self performReplacementsForRange:[self editedRange]];
     [super processEditing];
@@ -90,29 +82,16 @@
     [self applyStylesToRange:extendedRange];
 }
 
-- (void)update:(NSRange)range {
-    
-    [self addAttributes:self.bodyAttributes range:NSMakeRange(0, self.length)];
-    
-    [self applyStylesToRange:[[self string] lineRangeForRange:range]];
-}
-
-- (void)update {
-    [self update:NSMakeRange(0, self.length)];
-}
-
 - (void)applyStylesToRange:(NSRange)searchRange {
     NSDictionary* attributeDictionary = self.attributeDictionary;
     NSString* backingString = [_backingStore string];
+    NSDictionary* bodyAttributes  = self.bodyAttributes;
+    [self addAttributes:bodyAttributes range:searchRange];
     [attributeDictionary enumerateKeysAndObjectsUsingBlock:^(NSRegularExpression* regex, NSDictionary* attributes, BOOL* stop) {
         [regex enumerateMatchesInString:backingString options:0 range:searchRange
                              usingBlock:^(NSTextCheckingResult *match, NSMatchingFlags flags, BOOL *stop) {
                                  NSRange matchRange = [match rangeAtIndex:1];
                                  [self addAttributes:attributes range:matchRange];
-                                 
-                                 if (NSMaxRange(matchRange)+1 < self.length) {
-                                     [self addAttributes:self.bodyAttributes range:NSMakeRange(NSMaxRange(matchRange)+1, 1)];
-                                 }
                              }];
         
     }];

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -59,6 +59,14 @@
     [self endEditing];
 }
 
+- (void)addAttributes:(NSDictionary *)attrs range:(NSRange)range {
+    [self beginEditing];
+    
+    [super addAttributes:attrs range:range];
+    
+    [self endEditing];
+}
+
 - (void)processEditing {
     [self performReplacementsForRange:[self editedRange]];
     [super processEditing];
@@ -119,12 +127,16 @@
                       };
 }
 
-- (void)update {
+- (void)update:(NSRange)range {
     [self createHighlightPatterns];
     
     [self addAttributes:_bodyFont range:NSMakeRange(0, self.length)];
     
-    [self applyStylesToRange:NSMakeRange(0, self.length)];
+    [self applyStylesToRange:[[self.attributedString mutableString] lineRangeForRange:range]];
+}
+
+- (void)update {
+    [self update:NSMakeRange(0, self.length)];
 }
 
 - (void)applyStylesToRange:(NSRange)searchRange {

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -8,6 +8,9 @@
 
 #import "RFMarkdownSyntaxStorage.h"
 
+#define FONT_SIZE 14
+#define BODY_FONT [UIFont fontWithName:@"Menlo" size:FONT_SIZE]
+
 @interface RFMarkdownSyntaxStorage ()
 
 @property (nonatomic, strong) NSMutableAttributedString *attributedString;
@@ -21,7 +24,8 @@
 
 - (id)init {
     if (self = [super init]) {
-        _bodyFont = @{NSFontAttributeName:[UIFont systemFontOfSize:12], NSForegroundColorAttributeName:[UIColor blackColor],NSUnderlineStyleAttributeName:[NSNumber numberWithInt:NSUnderlineStyleNone]};
+        
+        _bodyFont = @{NSFontAttributeName:BODY_FONT, NSForegroundColorAttributeName:[UIColor blackColor],NSUnderlineStyleAttributeName:[NSNumber numberWithInt:NSUnderlineStyleNone]};
         _attributedString = [NSMutableAttributedString new];
         
         [self createHighlightPatterns];
@@ -68,11 +72,17 @@
 }
 
 - (void)createHighlightPatterns {
-    NSDictionary *boldAttributes = @{NSFontAttributeName:[UIFont boldSystemFontOfSize:12]};
-    NSDictionary *italicAttributes = @{NSFontAttributeName:[UIFont italicSystemFontOfSize:12]};
-    NSDictionary *boldItalicAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"HelveticaNeue-BoldItalic" size:11.5]};
+    NSDictionary *boldAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-Bold" size:FONT_SIZE]};
+    NSDictionary *italicAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-Italic" size:FONT_SIZE]};
+    NSDictionary *boldItalicAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-BoldItalic" size:FONT_SIZE]};
     
     NSDictionary *codeAttributes = @{NSForegroundColorAttributeName:[UIColor grayColor]};
+    
+    NSDictionary *headerOneAttributes = @{NSFontAttributeName:[UIFont fontWithName:@"Menlo-Bold" size:FONT_SIZE], NSUnderlineStyleAttributeName:[NSNumber numberWithInt:NSUnderlineStyleSingle], NSUnderlineColorAttributeName:[UIColor colorWithWhite:0.933 alpha:1.0]};
+    NSDictionary *headerTwoAttributes = headerOneAttributes;
+    NSDictionary *headerThreeAttributes = headerOneAttributes;
+    
+    NSDictionary *strikethroughAttributes = @{NSFontAttributeName:BODY_FONT, NSStrikethroughStyleAttributeName:@(NSUnderlineStyleSingle)};
     
     /*
      NSDictionary *headerOneAttributes = @{NSFontAttributeName:[UIFont boldSystemFontOfSize:14]};
@@ -95,12 +105,17 @@
     
     _attributeDictionary = @{
                       @"[a-zA-Z0-9\t\n ./<>?;:\\\"'`!@#$%^&*()[]{}_+=|\\-]":_bodyFont,
+                      @"~~(\\*(\\w+(\\s\\w+)*)\\*)~~":strikethroughAttributes,
                       @"\\**(?:^|[^*])(\\*\\*(\\w+(\\s\\w+)*)\\*\\*)":boldAttributes,
                       @"\\**(?:^|[^*])(\\*(\\w+(\\s\\w+)*)\\*)":italicAttributes,
                       @"(\\*\\*\\*\\w+(\\s\\w+)*\\*\\*\\*)":boldItalicAttributes,
                       @"(`\\w+(\\s\\w+)*`)":codeAttributes,
                       @"(```\n([\\s\n\\d\\w[/[\\.,-\\/#!?@$%\\^&\\*;:|{}<>+=\\-'_~()\\\"\\[\\]\\\\]/]]*)\n```)":codeAttributes,
-                      @"(\\[\\w+(\\s\\w+)*\\]\\(\\w+\\w[/[\\.,-\\/#!?@$%\\^&\\*;:|{}<>+=\\-'_~()\\\"\\[\\]\\\\]/ \\w+]*\\))":linkAttributes
+                      @"(\\[\\w+(\\s\\w+)*\\]\\(\\w+\\w[/[\\.,-\\/#!?@$%\\^&\\*;:|{}<>+=\\-'_~()\\\"\\[\\]\\\\]/ \\w+]*\\))":linkAttributes,
+                      @"(\\[\\[\\w+(\\s\\w+)*\\]\\])":linkAttributes,
+                      @"(\\#\\s?\\w*(\\s\\w+)*\\n)":headerOneAttributes,
+                      @"(\\##\\s?\\w*(\\s\\w+)*\\n)":headerTwoAttributes,
+                      @"(\\###\\s?\\w*(\\s\\w+)*\\n)":headerThreeAttributes
                       };
 }
 

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -1,10 +1,24 @@
 //
 //  RFMarkdownSyntaxStorage.m
-//  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/6/13.
-//  Copyright (c) 2013 Rudd Fawcett. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
 //
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "RFMarkdownSyntaxStorage.h"
 
@@ -158,5 +172,8 @@
         }];
     }
 }
+
+#pragma mark Property Access
+
 
 @end

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -104,7 +104,7 @@
 - (void)applyStylesToRange:(NSRange)searchRange {
     NSDictionary* attributeDictionary = self.attributeDictionary;
     NSString* backingString = [_backingStore string];
-    [attributeDictionary enumerateKeysAndObjectsUsingBlock:^(id  __nonnull regex, id  __nonnull attributes, BOOL * __nonnull stop) {
+    [attributeDictionary enumerateKeysAndObjectsUsingBlock:^(NSRegularExpression* regex, NSDictionary* attributes, BOOL* stop) {
         [regex enumerateMatchesInString:backingString options:0 range:searchRange
                              usingBlock:^(NSTextCheckingResult *match, NSMatchingFlags flags, BOOL *stop) {
                                  NSRange matchRange = [match rangeAtIndex:1];

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -113,7 +113,9 @@
 -(UIFont *)bodyFont {
     if (!_bodyFont) {
         UIFontDescriptor* baseDescriptor = [UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleBody];
-        _bodyFont = [UIFont fontWithName:@"Menlo" size:baseDescriptor.pointSize];
+        CGFloat baseFontSize = baseDescriptor.pointSize;
+        CGFloat bodyFontSize = ceilf(baseFontSize * 14 / 17 / 2) * 2;
+        _bodyFont = [UIFont fontWithName:@"Menlo" size:bodyFontSize];
     }
     return _bodyFont;
 }

--- a/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
+++ b/RFMarkdownTextView/RFMarkdownSyntaxStorage.m
@@ -105,7 +105,7 @@
     
     _attributeDictionary = @{
                       @"[a-zA-Z0-9\t\n ./<>?;:\\\"'`!@#$%^&*()[]{}_+=|\\-]":_bodyFont,
-                      @"~~(\\*(\\w+(\\s\\w+)*)\\*)~~":strikethroughAttributes,
+                      @"~~(\\w+(\\s\\w+)*)~~":strikethroughAttributes,
                       @"\\**(?:^|[^*])(\\*\\*(\\w+(\\s\\w+)*)\\*\\*)":boldAttributes,
                       @"\\**(?:^|[^*])(\\*(\\w+(\\s\\w+)*)\\*)":italicAttributes,
                       @"(\\*\\*\\*\\w+(\\s\\w+)*\\*\\*\\*)":boldItalicAttributes,

--- a/RFMarkdownTextView/RFMarkdownTextView.h
+++ b/RFMarkdownTextView/RFMarkdownTextView.h
@@ -23,7 +23,7 @@
 //
 
 #import <UIKit/UIKit.h>
-@import RFKeyboardToolbar;
+#import <RFKeyboardToolbar/RFKeyboardToolbar.h>
 
 @class RFMarkdownTextView;
 

--- a/RFMarkdownTextView/RFMarkdownTextView.h
+++ b/RFMarkdownTextView/RFMarkdownTextView.h
@@ -2,8 +2,24 @@
 //  RFMarkdownTextView.h
 //  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/1/13.
-//  Copyright (c) 2013 Rudd Fawcett. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import <UIKit/UIKit.h>

--- a/RFMarkdownTextView/RFMarkdownTextView.h
+++ b/RFMarkdownTextView/RFMarkdownTextView.h
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 @import RFKeyboardToolbar;
-#import "RFMarkdownSyntaxStorage.h"
 
 @class RFMarkdownTextView;
 

--- a/RFMarkdownTextView/RFMarkdownTextView.h
+++ b/RFMarkdownTextView/RFMarkdownTextView.h
@@ -7,10 +7,19 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "RFKeyboardToolbar.h"
-#import "RFToolbarButton.h"
+@import RFKeyboardToolbar;
 #import "RFMarkdownSyntaxStorage.h"
 
+@class RFMarkdownTextView;
+
+typedef void (^ImageBlock)(NSString *);
+
+@protocol ImagePickerDelegate <NSObject>
+- (void)textViewWantsImage:(RFMarkdownTextView *)textView completion:(ImageBlock)imageBlock;
+@end
+
 @interface RFMarkdownTextView : UITextView <UITextViewDelegate>
+
+@property (nonatomic, weak) id<ImagePickerDelegate> imagePickerDelegate;
 
 @end

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -156,12 +156,18 @@
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
     if ([text isEqualToString:@"\n"]) {
+        // Matches " *" and " - [ ]"
         NSString *pattern = @" *(\\*|- \\[( |x)\\]) ";
         NSError  *error = nil;
         NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
         
         if (range.location > 0) {
             NSRange oldRange = NSMakeRange(MAX(0, range.location - 1), range.length);
+            
+            // Don't match the previous line if the user is making a newline on an empty line
+            if ([[self.text substringWithRange:NSMakeRange(oldRange.location, 1)] isEqualToString:@"\n"]) {
+                return YES;
+            }
             NSRange previousLineRange = [self.text lineRangeForRange:oldRange];
             
             NSArray *matches = [regex matchesInString:self.text options:0 range: previousLineRange];

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -7,6 +7,7 @@
 //
 
 #import "RFMarkdownTextView.h"
+#import "RFMarkdownSyntaxStorage.h"
 
 @interface RFMarkdownTextView ()
 

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -246,12 +246,12 @@
 }
 
 
--(void)forwardInvocation:(nonnull NSInvocation *)invocation {
+-(void)forwardInvocation:(NSInvocation *)invocation {
     [invocation setTarget:self.delegateTarget];
     [invocation invoke];
 }
 
--(nullable NSMethodSignature *)methodSignatureForSelector:(nonnull SEL)sel {
+-(nullable NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
     const SEL mySelector = @selector(methodSignatureForSelector:);
 
     id<NSObject> target = self.delegateTarget;

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -21,10 +21,8 @@
 @synthesize priorInset;
 
 - (id)initWithFrame:(CGRect)frame {
-    NSAttributedString *attrString = [[NSAttributedString alloc] initWithString:@"" attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:12]}];
     
     _syntaxStorage = [RFMarkdownSyntaxStorage new];
-    [_syntaxStorage appendAttributedString:attrString];
     
     CGRect newTextViewRect = frame;
     NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
@@ -183,8 +181,5 @@
     return YES;
 }
 
-- (void)textViewDidChange:(UITextView *)textView {
-    [_syntaxStorage update:self.selectedRange];
-}
 
 @end

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -192,7 +192,7 @@
 
 #pragma mark Property Access
 
--(void)setDelegate:(id<UITextViewDelegate> __nullable)delegate {
+-(void)setDelegate:(id<UITextViewDelegate>) delegate {
     _delegateProxy.delegateTarget = delegate;
 }
 

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -46,7 +46,6 @@
     [_syntaxStorage addLayoutManager:layoutManager];
     
     if (self = [super initWithFrame:frame textContainer:container]) {
-        self.inputAccessoryView = [RFKeyboardToolbar toolbarWithButtons:[self buttons]];
         _delegateProxy = [RFMarkdownTextView_DelegateProxy alloc];
         [super setDelegate:_delegateProxy];
     }
@@ -182,6 +181,13 @@
 
 - (RFToolbarButton *)createButtonWithTitle:(NSString*)title andEventHandler:(void(^)())handler {
     return [RFToolbarButton buttonWithTitle:title andEventHandler:handler forControlEvents:UIControlEventTouchUpInside];
+}
+
+-(void)willMoveToSuperview:(UIView *)newSuperview {
+    [super willMoveToSuperview:newSuperview];
+    if (!self.inputAccessoryView) {
+        self.inputAccessoryView = [RFKeyboardToolbar toolbarWithButtons:[self buttons]];
+    }
 }
 
 #pragma mark Property Access

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -33,7 +33,7 @@
 
 - (id)initWithFrame:(CGRect)frame {
     
-    _syntaxStorage = [RFMarkdownSyntaxStorage new];
+    RFMarkdownSyntaxStorage* syntaxStorage = [RFMarkdownSyntaxStorage new];
     
     CGRect newTextViewRect = frame;
     NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
@@ -43,9 +43,10 @@
     container.widthTracksTextView = YES;
     
     [layoutManager addTextContainer:container];
-    [_syntaxStorage addLayoutManager:layoutManager];
+    [syntaxStorage addLayoutManager:layoutManager];
     
     if (self = [super initWithFrame:frame textContainer:container]) {
+        _syntaxStorage = syntaxStorage;
         _delegateProxy = [RFMarkdownTextView_DelegateProxy alloc];
         [super setDelegate:_delegateProxy];
     }

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -183,7 +183,7 @@
 }
 
 - (void)textViewDidChange:(UITextView *)textView {
-    [_syntaxStorage update];
+    [_syntaxStorage update:self.selectedRange];
 }
 
 @end

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -11,10 +11,13 @@
 @interface RFMarkdownTextView ()
 
 @property (strong,nonatomic) RFMarkdownSyntaxStorage *syntaxStorage;
+@property (nonatomic, assign) UIEdgeInsets priorInset;
 
 @end
 
 @implementation RFMarkdownTextView
+@synthesize imagePickerDelegate;
+@synthesize priorInset;
 
 - (id)initWithFrame:(CGRect)frame {
     NSAttributedString *attrString = [[NSAttributedString alloc] initWithString:@"" attributes:@{NSFontAttributeName: [UIFont systemFontOfSize:12]}];
@@ -36,44 +39,68 @@
         self.delegate = self;
         self.inputAccessoryView = [RFKeyboardToolbar toolbarWithButtons:[self buttons]];
     }
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(keyboardWillShow:)
+                                                 name:UIKeyboardWillShowNotification object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(keyboardWillBeHidden:)
+                                                 name:UIKeyboardWillHideNotification object:nil];
+    
     return self;
 }
 
+- (void)keyboardWillShow:(NSNotification*)notification {
+    CGRect keyboardRect = [self convertRect:[[[notification userInfo] objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue] fromView:nil];
+    if (CGRectIsEmpty(keyboardRect)) {
+        return;
+    }
+    
+    self.priorInset = self.contentInset;
+    
+    self.contentInset = UIEdgeInsetsMake(self.contentInset.top, self.contentInset.left, keyboardRect.size.height, self.contentInset.right);
+    self.scrollIndicatorInsets = self.contentInset;
+}
 
+- (void)keyboardWillBeHidden:(NSNotification*)notification {
+    self.contentInset = priorInset;
+    self.scrollIndicatorInsets = self.contentInset;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 
 - (NSArray *)buttons {
-    return @[[self createButtonWithTitle:@"#" andEventHandler:^{ [self insertText:@"#"]; }],
-             [self createButtonWithTitle:@"*" andEventHandler:^{ [self insertText:@"*"]; }],
-             [self createButtonWithTitle:@"_" andEventHandler:^{ [self insertText:@"_"]; }],
+    return @[
+             [self createButtonWithTitle:@"#" andEventHandler:^{ [self insertText:@"#"]; }],
+             [self createButtonWithTitle:@"*" andEventHandler:^{
+                 [self insertText:@"*"];
+             }],
+             [self createButtonWithTitle:@"->|" andEventHandler:^{ [self insertText:@"  "]; }],
+             [self createButtonWithTitle:@"[[" andEventHandler:^{
+                 NSRange selectionRange = self.selectedRange;
+                 selectionRange.location += 2;
+                 [self insertText:@"[[]]"];
+                 [self setSelectionRange:selectionRange];
+             }],
              [self createButtonWithTitle:@"`" andEventHandler:^{ [self insertText:@"`"]; }],
-             [self createButtonWithTitle:@"@" andEventHandler:^{ [self insertText:@"@"]; }],
+             [self createButtonWithTitle:@"Photo" andEventHandler:^{
+                 ImageBlock block = ^(NSString *imagePath) {
+                     NSRange selectionRange = self.selectedRange;
+                     selectionRange.location += 2;
+                     [self insertText:[NSString stringWithFormat:@"![](img/%@)", imagePath]];
+                     [self setSelectionRange:self.selectedRange];
+                 };
+                 [imagePickerDelegate textViewWantsImage:self completion:block];
+             }],
              [self createButtonWithTitle:@"Link" andEventHandler:^{
                  NSRange selectionRange = self.selectedRange;
                  selectionRange.location += 1;
                  [self insertText:@"[]()"];
                  [self setSelectionRange:selectionRange];
                  
-             }],
-             [self createButtonWithTitle:@"Codeblock" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += self.text.length == 0 ? 3 : 4;
-                 
-                 [self insertText: self.text.length == 0 ? @"```\n```" : @"\n```\n```"];
-                 [self setSelectionRange:selectionRange];
-             }],
-             [self createButtonWithTitle:@"Image" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += 2;
-                 
-                 [self insertText:@"![]()"];
-                 [self setSelectionRange:self.selectedRange];
-             }],
-             [self createButtonWithTitle:@"Task" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += 7;
-                 
-                 [self insertText:self.text.length == 0 ? @"- [ ] " : @"\n- [ ] "];
-                 [self setSelectionRange:selectionRange];
              }],
              [self createButtonWithTitle:@"Quote" andEventHandler:^{
                  NSRange selectionRange = self.selectedRange;

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -87,57 +87,76 @@
 }
 
 - (NSArray *)buttons {
+    RFMarkdownTextView __weak* weakSelf = self;
     return @[
-             [self createButtonWithTitle:@"#" andEventHandler:^{ [self insertText:@"#"]; }],
+             [self createButtonWithTitle:@"#" andEventHandler:^{ [weakSelf insertText:@"#"]; }],
              [self createButtonWithTitle:@"*" andEventHandler:^{
-                 if (self.selectedRange.length > 0) {
-                     [self wrapSelectedRangeWithString:@"*"];
+                if(!weakSelf) {
+                    return;
+                }
+                 if (weakSelf.selectedRange.length > 0) {
+                     [weakSelf wrapSelectedRangeWithString:@"*"];
                  } else {
-                     [self insertText:@"*"];
+                     [weakSelf insertText:@"*"];
                  }
              }],
-             [self createButtonWithTitle:@"->|" andEventHandler:^{ [self insertText:@"  "]; }],
-             [self createButtonWithTitle:@"[[" andEventHandler:^{
-                 if (self.selectedRange.length > 0) {
-                     [self wrapSelectedRangeWithStartString:@"[[" endString:@"]]"];
-                     NSString *linkName = [self textInRange:self.selectedTextRange];
-                     [self replaceRange:self.selectedTextRange withText:[linkName capitalizedString]];
+             [self createButtonWithTitle:@"->|" andEventHandler:^{ [weakSelf insertText:@"  "]; }],
+             [self createButtonWithTitle:@"[[" andEventHandler:^{                
+                 if(!weakSelf) {
+                     return;
+                 }
+                 if (weakSelf.selectedRange.length > 0) {
+                     [weakSelf wrapSelectedRangeWithStartString:@"[[" endString:@"]]"];
+                     NSString *linkName = [weakSelf textInRange:weakSelf.selectedTextRange];
+                     [weakSelf replaceRange:weakSelf.selectedTextRange withText:[linkName capitalizedString]];
                  } else {
-                     NSRange selectionRange = self.selectedRange;
+                     NSRange selectionRange = weakSelf.selectedRange;
                      selectionRange.location += 2;
-                     [self insertText:@"[[]]"];
-                     [self setSelectionRange:selectionRange];
+                     [weakSelf insertText:@"[[]]"];
+                     [weakSelf setSelectionRange:selectionRange];
                  }
              }],
              [self createButtonWithTitle:@"`" andEventHandler:^{
-                 if (self.selectedRange.length > 0) {
-                     [self wrapSelectedRangeWithString:@"`"];
+                 if(!weakSelf) {
+                     return;
+                 }
+                 if (weakSelf.selectedRange.length > 0) {
+                     [weakSelf wrapSelectedRangeWithString:@"`"];
                  } else {
-                     [self insertText:@"`"];
+                     [weakSelf insertText:@"`"];
                  }
              }],
              [self createButtonWithTitle:@"Photo" andEventHandler:^{
+                 if(!weakSelf) {
+                     return;
+                 }
                  ImageBlock block = ^(NSString *imagePath) {
-                     NSRange selectionRange = self.selectedRange;
+                     NSRange selectionRange = weakSelf.selectedRange;
                      selectionRange.location += 2;
-                     [self insertText:[NSString stringWithFormat:@"![](img/%@)", imagePath]];
-                     [self setSelectionRange:self.selectedRange];
+                     [weakSelf insertText:[NSString stringWithFormat:@"![](img/%@)", imagePath]];
+                     [weakSelf setSelectionRange:weakSelf.selectedRange];
                  };
-                 [imagePickerDelegate textViewWantsImage:self completion:block];
+                 [weakSelf.imagePickerDelegate textViewWantsImage:weakSelf completion:block];
              }],
              [self createButtonWithTitle:@"Link" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
+                 if(!weakSelf) {
+                     return;
+                 }
+                 NSRange selectionRange = weakSelf.selectedRange;
                  selectionRange.location += 1;
-                 [self insertText:@"[]()"];
-                 [self setSelectionRange:selectionRange];
+                 [weakSelf insertText:@"[]()"];
+                 [weakSelf setSelectionRange:selectionRange];
                  
              }],
              [self createButtonWithTitle:@"Quote" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
+                 if(!weakSelf) {
+                     return;
+                 }
+                 NSRange selectionRange = weakSelf.selectedRange;
                  selectionRange.location += 3;
 
-                 [self insertText:self.text.length == 0 ? @"> " : @"\n> "];
-                 [self setSelectionRange:selectionRange];
+                 [weakSelf insertText:weakSelf.text.length == 0 ? @"> " : @"\n> "];
+                 [weakSelf setSelectionRange:selectionRange];
              }]];
 }
 

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -72,20 +72,51 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+- (void)wrapSelectedRangeWithString:(NSString *)string {
+    [self wrapSelectedRangeWithStartString:string endString:string];
+}
+
+- (void)wrapSelectedRangeWithStartString:(NSString *)startString endString:(NSString *)endString {
+    NSUInteger length = self.selectedRange.length;
+    NSUInteger location = self.selectedRange.location;
+    [self setSelectionRange:NSMakeRange(self.selectedRange.location, 0)];
+    [self insertText:startString];
+    NSUInteger endLocation = self.selectedRange.location + length;
+    [self setSelectionRange:NSMakeRange(endLocation, 0)];
+    [self insertText:endString];
+    [self setSelectionRange:NSMakeRange(location + startString.length, length)];
+}
+
 - (NSArray *)buttons {
     return @[
              [self createButtonWithTitle:@"#" andEventHandler:^{ [self insertText:@"#"]; }],
              [self createButtonWithTitle:@"*" andEventHandler:^{
-                 [self insertText:@"*"];
+                 if (self.selectedRange.length > 0) {
+                     [self wrapSelectedRangeWithString:@"*"];
+                 } else {
+                     [self insertText:@"*"];
+                 }
              }],
              [self createButtonWithTitle:@"->|" andEventHandler:^{ [self insertText:@"  "]; }],
              [self createButtonWithTitle:@"[[" andEventHandler:^{
-                 NSRange selectionRange = self.selectedRange;
-                 selectionRange.location += 2;
-                 [self insertText:@"[[]]"];
-                 [self setSelectionRange:selectionRange];
+                 if (self.selectedRange.length > 0) {
+                     [self wrapSelectedRangeWithStartString:@"[[" endString:@"]]"];
+                     NSString *linkName = [self textInRange:self.selectedTextRange];
+                     [self replaceRange:self.selectedTextRange withText:[linkName capitalizedString]];
+                 } else {
+                     NSRange selectionRange = self.selectedRange;
+                     selectionRange.location += 2;
+                     [self insertText:@"[[]]"];
+                     [self setSelectionRange:selectionRange];
+                 }
              }],
-             [self createButtonWithTitle:@"`" andEventHandler:^{ [self insertText:@"`"]; }],
+             [self createButtonWithTitle:@"`" andEventHandler:^{
+                 if (self.selectedRange.length > 0) {
+                     [self wrapSelectedRangeWithString:@"`"];
+                 } else {
+                     [self insertText:@"`"];
+                 }
+             }],
              [self createButtonWithTitle:@"Photo" andEventHandler:^{
                  ImageBlock block = ^(NSString *imagePath) {
                      NSRange selectionRange = self.selectedRange;
@@ -121,6 +152,28 @@
 
 - (RFToolbarButton *)createButtonWithTitle:(NSString*)title andEventHandler:(void(^)())handler {
     return [RFToolbarButton buttonWithTitle:title andEventHandler:handler forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
+    if ([text isEqualToString:@"\n"]) {
+        NSString *pattern = @" *(\\*|- \\[( |x)\\]) ";
+        NSError  *error = nil;
+        NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
+        
+        if (range.location > 0) {
+            NSRange oldRange = NSMakeRange(MAX(0, range.location - 1), range.length);
+            NSRange previousLineRange = [self.text lineRangeForRange:oldRange];
+            
+            NSArray *matches = [regex matchesInString:self.text options:0 range: previousLineRange];
+            
+            if (matches.count > 0) {
+                NSString *previousPrefix = [self.text substringWithRange:[matches[0] rangeAtIndex:0]];
+                [self insertText:[NSString stringWithFormat:@"\n%@", previousPrefix]];
+                return NO;
+            }
+        }
+    }
+    return YES;
 }
 
 - (void)textViewDidChange:(UITextView *)textView {

--- a/RFMarkdownTextView/RFMarkdownTextView.m
+++ b/RFMarkdownTextView/RFMarkdownTextView.m
@@ -251,7 +251,7 @@
     [invocation invoke];
 }
 
--(nullable NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
+-(NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
     const SEL mySelector = @selector(methodSignatureForSelector:);
 
     id<NSObject> target = self.delegateTarget;

--- a/RFMarkdownTextView/RFMarkdownToolbarButton.h
+++ b/RFMarkdownTextView/RFMarkdownToolbarButton.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Rex Finn. All rights reserved.
 //
 
-#import "RFToolbarButton.h"
+@import RFKeyboardToolbar;
 
 @interface RFMarkdownToolbarButton : RFToolbarButton
 

--- a/RFMarkdownTextView/RFMarkdownToolbarButton.m
+++ b/RFMarkdownTextView/RFMarkdownToolbarButton.m
@@ -2,8 +2,24 @@
 //  RFMarkdownToolbarButton.m
 //  RFMarkdownTextViewDemo
 //
-//  Created by Rudd Fawcett on 12/19/13.
-//  Copyright (c) 2013 Rex Finn. All rights reserved.
+//    Derived from RFMarkdownTextView Copyright (c) 2015 Rudd Fawcett
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of
+//    this software and associated documentation files (the "Software"), to deal in
+//    the Software without restriction, including without limitation the rights to
+//    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//    the Software, and to permit persons to whom the Software is furnished to do so,
+//    subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
 #import "RFMarkdownToolbarButton.h"

--- a/RFMarkdownTextViewDemo/Podfile.lock
+++ b/RFMarkdownTextViewDemo/Podfile.lock
@@ -5,6 +5,6 @@ DEPENDENCIES:
   - RFKeyboardToolbar (~> 1.3)
 
 SPEC CHECKSUMS:
-  RFKeyboardToolbar: f816e75a78ad3c3bda565be5678288003be4c8d8
+  RFKeyboardToolbar: c96a7d9458564d1fedc8ef6844b6c467934aade2
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.37.2

--- a/RFMarkdownTextViewDemo/RFMarkdownTextViewDemo.xcodeproj/project.pbxproj
+++ b/RFMarkdownTextViewDemo/RFMarkdownTextViewDemo.xcodeproj/project.pbxproj
@@ -1,1174 +1,536 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>140D57BB1EFCDC96C2A35264</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods/Pods.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>61255C9A23AF453BAD153CFC</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>862CD844BB180D8F81485001</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods/Pods.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8A0BDFC2C5C4CF6581776641</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>140D57BB1EFCDC96C2A35264</string>
-				<string>862CD844BB180D8F81485001</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8D8974789EB0412CA72B3577</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>CE041EFD1852A74100F79297</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RFMarkdownSyntaxStorage.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CE041EFE1852A74100F79297</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RFMarkdownSyntaxStorage.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CE041EFF1852A74100F79297</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CE041EFE1852A74100F79297</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CEEF0E7A184EA3FE00B7DEDF</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>CEEF0E7B184EA3FE00B7DEDF</string>
-				<string>CEEF0E7C184EA3FE00B7DEDF</string>
-				<string>CE041EFD1852A74100F79297</string>
-				<string>CE041EFE1852A74100F79297</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>RFMarkdownTextView</string>
-			<key>path</key>
-			<string>../../RFMarkdownTextView</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CEEF0E7B184EA3FE00B7DEDF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RFMarkdownTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CEEF0E7C184EA3FE00B7DEDF</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RFMarkdownTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CEEF0E7D184EA3FE00B7DEDF</key>
-		<dict>
-			<key>fileRef</key>
-			<string>CEEF0E7C184EA3FE00B7DEDF</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EE92B928DE3645F2949E9F61</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8D8974789EB0412CA72B3577</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>EFE0AE2605BA459980E4444B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>F173710A184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F173711C184C2F5500422999</string>
-				<string>F1737135184C2F5500422999</string>
-				<string>F1737115184C2F5500422999</string>
-				<string>F1737114184C2F5500422999</string>
-				<string>8A0BDFC2C5C4CF6581776641</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F173710B184C2F5500422999</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0500</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Rex Finn</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>F173712D184C2F5500422999</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>F1737112184C2F5500422999</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>F173710E184C2F5500422999</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>F173710A184C2F5500422999</string>
-			<key>productRefGroup</key>
-			<string>F1737114184C2F5500422999</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>F1737112184C2F5500422999</string>
-				<string>F173712D184C2F5500422999</string>
-			</array>
-		</dict>
-		<key>F173710E184C2F5500422999</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>F173713D184C2F5500422999</string>
-				<string>F173713E184C2F5500422999</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>F173710F184C2F5500422999</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F1737147184C2F7600422999</string>
-				<string>CE041EFF1852A74100F79297</string>
-				<string>F1737127184C2F5500422999</string>
-				<string>CEEF0E7D184EA3FE00B7DEDF</string>
-				<string>F1737123184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F1737110184C2F5500422999</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F1737119184C2F5500422999</string>
-				<string>F173711B184C2F5500422999</string>
-				<string>F1737117184C2F5500422999</string>
-				<string>EE92B928DE3645F2949E9F61</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F1737111184C2F5500422999</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F1737121184C2F5500422999</string>
-				<string>F1737129184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F1737112184C2F5500422999</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>F173713F184C2F5500422999</string>
-			<key>buildPhases</key>
-			<array>
-				<string>61255C9A23AF453BAD153CFC</string>
-				<string>F173710F184C2F5500422999</string>
-				<string>F1737110184C2F5500422999</string>
-				<string>F1737111184C2F5500422999</string>
-				<string>EFE0AE2605BA459980E4444B</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RFMarkdownTextViewDemo</string>
-			<key>productName</key>
-			<string>RFMarkdownTextViewDemo</string>
-			<key>productReference</key>
-			<string>F1737113184C2F5500422999</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>F1737113184C2F5500422999</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemo.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>F1737114184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F1737113184C2F5500422999</string>
-				<string>F173712E184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737115184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F1737116184C2F5500422999</string>
-				<string>F1737118184C2F5500422999</string>
-				<string>F173711A184C2F5500422999</string>
-				<string>F173712F184C2F5500422999</string>
-				<string>8D8974789EB0412CA72B3577</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737116184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>F1737117184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737116184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1737118184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>F1737119184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737118184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F173711A184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>F173711B184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F173711A184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F173711C184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F1737125184C2F5500422999</string>
-				<string>F1737126184C2F5500422999</string>
-				<string>F1737145184C2F7600422999</string>
-				<string>F1737146184C2F7600422999</string>
-				<string>F1737128184C2F5500422999</string>
-				<string>CEEF0E7A184EA3FE00B7DEDF</string>
-				<string>F173711D184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemo</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F173711D184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F173711E184C2F5500422999</string>
-				<string>F173711F184C2F5500422999</string>
-				<string>F1737122184C2F5500422999</string>
-				<string>F1737124184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F173711E184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemo-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F173711F184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F1737120184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737120184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737121184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F173711F184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1737122184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737123184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737122184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1737124184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemo-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737125184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737126184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737127184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737126184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1737128184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737129184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737128184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F173712A184C2F5500422999</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F173713C184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F173712B184C2F5500422999</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F1737130184C2F5500422999</string>
-				<string>F1737132184C2F5500422999</string>
-				<string>F1737131184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F173712C184C2F5500422999</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F173713A184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F173712D184C2F5500422999</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>F1737142184C2F5500422999</string>
-			<key>buildPhases</key>
-			<array>
-				<string>F173712A184C2F5500422999</string>
-				<string>F173712B184C2F5500422999</string>
-				<string>F173712C184C2F5500422999</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>F1737134184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>RFMarkdownTextViewDemoTests</string>
-			<key>productName</key>
-			<string>RFMarkdownTextViewDemoTests</string>
-			<key>productReference</key>
-			<string>F173712E184C2F5500422999</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>F173712E184C2F5500422999</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemoTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>F173712F184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>F1737130184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F173712F184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1737131184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737116184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1737132184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F173711A184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F1737133184C2F5500422999</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>F173710B184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>F1737112184C2F5500422999</string>
-			<key>remoteInfo</key>
-			<string>RFMarkdownTextViewDemo</string>
-		</dict>
-		<key>F1737134184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>F1737112184C2F5500422999</string>
-			<key>targetProxy</key>
-			<string>F1737133184C2F5500422999</string>
-		</dict>
-		<key>F1737135184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F173713B184C2F5500422999</string>
-				<string>F1737136184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemoTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737136184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F1737137184C2F5500422999</string>
-				<string>F1737138184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737137184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemoTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737138184C2F5500422999</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F1737139184C2F5500422999</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737139184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F173713A184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737138184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F173713B184C2F5500422999</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>RFMarkdownTextViewDemoTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F173713C184C2F5500422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F173713B184C2F5500422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F173713D184C2F5500422999</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>F173713E184C2F5500422999</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>F173713F184C2F5500422999</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>F1737140184C2F5500422999</string>
-				<string>F1737141184C2F5500422999</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>F1737140184C2F5500422999</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>140D57BB1EFCDC96C2A35264</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>F1737141184C2F5500422999</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>862CD844BB180D8F81485001</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>F1737142184C2F5500422999</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>F1737143184C2F5500422999</string>
-				<string>F1737144184C2F5500422999</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>F1737143184C2F5500422999</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/RFMarkdownTextViewDemo.app/RFMarkdownTextViewDemo</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>RFMarkdownTextViewDemoTests/RFMarkdownTextViewDemoTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>F1737144184C2F5500422999</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/RFMarkdownTextViewDemo.app/RFMarkdownTextViewDemo</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>RFMarkdownTextViewDemoTests/RFMarkdownTextViewDemoTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>F1737145184C2F7600422999</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737146184C2F7600422999</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F1737147184C2F7600422999</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F1737146184C2F7600422999</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>F173710B184C2F5500422999</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CE041EFF1852A74100F79297 /* RFMarkdownSyntaxStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = CE041EFE1852A74100F79297 /* RFMarkdownSyntaxStorage.m */; };
+		CEEF0E7D184EA3FE00B7DEDF /* RFMarkdownTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = CEEF0E7C184EA3FE00B7DEDF /* RFMarkdownTextView.m */; };
+		EE92B928DE3645F2949E9F61 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D8974789EB0412CA72B3577 /* libPods.a */; };
+		F1737117184C2F5500422999 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1737116184C2F5500422999 /* Foundation.framework */; };
+		F1737119184C2F5500422999 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1737118184C2F5500422999 /* CoreGraphics.framework */; };
+		F173711B184C2F5500422999 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F173711A184C2F5500422999 /* UIKit.framework */; };
+		F1737121184C2F5500422999 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F173711F184C2F5500422999 /* InfoPlist.strings */; };
+		F1737123184C2F5500422999 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F1737122184C2F5500422999 /* main.m */; };
+		F1737127184C2F5500422999 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F1737126184C2F5500422999 /* AppDelegate.m */; };
+		F1737129184C2F5500422999 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F1737128184C2F5500422999 /* Images.xcassets */; };
+		F1737130184C2F5500422999 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F173712F184C2F5500422999 /* XCTest.framework */; };
+		F1737131184C2F5500422999 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1737116184C2F5500422999 /* Foundation.framework */; };
+		F1737132184C2F5500422999 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F173711A184C2F5500422999 /* UIKit.framework */; };
+		F173713A184C2F5500422999 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F1737138184C2F5500422999 /* InfoPlist.strings */; };
+		F173713C184C2F5500422999 /* RFMarkdownTextViewDemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F173713B184C2F5500422999 /* RFMarkdownTextViewDemoTests.m */; };
+		F1737147184C2F7600422999 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F1737146184C2F7600422999 /* ViewController.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F1737133184C2F5500422999 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F173710B184C2F5500422999 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F1737112184C2F5500422999;
+			remoteInfo = RFMarkdownTextViewDemo;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		140D57BB1EFCDC96C2A35264 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		862CD844BB180D8F81485001 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		8D8974789EB0412CA72B3577 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CE041EFD1852A74100F79297 /* RFMarkdownSyntaxStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFMarkdownSyntaxStorage.h; sourceTree = "<group>"; };
+		CE041EFE1852A74100F79297 /* RFMarkdownSyntaxStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFMarkdownSyntaxStorage.m; sourceTree = "<group>"; };
+		CEEF0E7B184EA3FE00B7DEDF /* RFMarkdownTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFMarkdownTextView.h; sourceTree = "<group>"; };
+		CEEF0E7C184EA3FE00B7DEDF /* RFMarkdownTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFMarkdownTextView.m; sourceTree = "<group>"; };
+		F1737113184C2F5500422999 /* RFMarkdownTextViewDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RFMarkdownTextViewDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1737116184C2F5500422999 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		F1737118184C2F5500422999 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		F173711A184C2F5500422999 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		F173711E184C2F5500422999 /* RFMarkdownTextViewDemo-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RFMarkdownTextViewDemo-Info.plist"; sourceTree = "<group>"; };
+		F1737120184C2F5500422999 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F1737122184C2F5500422999 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		F1737124184C2F5500422999 /* RFMarkdownTextViewDemo-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RFMarkdownTextViewDemo-Prefix.pch"; sourceTree = "<group>"; };
+		F1737125184C2F5500422999 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		F1737126184C2F5500422999 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		F1737128184C2F5500422999 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		F173712E184C2F5500422999 /* RFMarkdownTextViewDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RFMarkdownTextViewDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F173712F184C2F5500422999 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		F1737137184C2F5500422999 /* RFMarkdownTextViewDemoTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RFMarkdownTextViewDemoTests-Info.plist"; sourceTree = "<group>"; };
+		F1737139184C2F5500422999 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F173713B184C2F5500422999 /* RFMarkdownTextViewDemoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RFMarkdownTextViewDemoTests.m; sourceTree = "<group>"; };
+		F1737145184C2F7600422999 /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		F1737146184C2F7600422999 /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F1737110184C2F5500422999 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1737119184C2F5500422999 /* CoreGraphics.framework in Frameworks */,
+				F173711B184C2F5500422999 /* UIKit.framework in Frameworks */,
+				F1737117184C2F5500422999 /* Foundation.framework in Frameworks */,
+				EE92B928DE3645F2949E9F61 /* libPods.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F173712B184C2F5500422999 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1737130184C2F5500422999 /* XCTest.framework in Frameworks */,
+				F1737132184C2F5500422999 /* UIKit.framework in Frameworks */,
+				F1737131184C2F5500422999 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8A0BDFC2C5C4CF6581776641 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				140D57BB1EFCDC96C2A35264 /* Pods.debug.xcconfig */,
+				862CD844BB180D8F81485001 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		CEEF0E7A184EA3FE00B7DEDF /* RFMarkdownTextView */ = {
+			isa = PBXGroup;
+			children = (
+				CEEF0E7B184EA3FE00B7DEDF /* RFMarkdownTextView.h */,
+				CEEF0E7C184EA3FE00B7DEDF /* RFMarkdownTextView.m */,
+				CE041EFD1852A74100F79297 /* RFMarkdownSyntaxStorage.h */,
+				CE041EFE1852A74100F79297 /* RFMarkdownSyntaxStorage.m */,
+			);
+			name = RFMarkdownTextView;
+			path = ../../RFMarkdownTextView;
+			sourceTree = "<group>";
+		};
+		F173710A184C2F5500422999 = {
+			isa = PBXGroup;
+			children = (
+				F173711C184C2F5500422999 /* RFMarkdownTextViewDemo */,
+				F1737135184C2F5500422999 /* RFMarkdownTextViewDemoTests */,
+				F1737115184C2F5500422999 /* Frameworks */,
+				F1737114184C2F5500422999 /* Products */,
+				8A0BDFC2C5C4CF6581776641 /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		F1737114184C2F5500422999 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F1737113184C2F5500422999 /* RFMarkdownTextViewDemo.app */,
+				F173712E184C2F5500422999 /* RFMarkdownTextViewDemoTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F1737115184C2F5500422999 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F1737116184C2F5500422999 /* Foundation.framework */,
+				F1737118184C2F5500422999 /* CoreGraphics.framework */,
+				F173711A184C2F5500422999 /* UIKit.framework */,
+				F173712F184C2F5500422999 /* XCTest.framework */,
+				8D8974789EB0412CA72B3577 /* libPods.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F173711C184C2F5500422999 /* RFMarkdownTextViewDemo */ = {
+			isa = PBXGroup;
+			children = (
+				F1737125184C2F5500422999 /* AppDelegate.h */,
+				F1737126184C2F5500422999 /* AppDelegate.m */,
+				F1737145184C2F7600422999 /* ViewController.h */,
+				F1737146184C2F7600422999 /* ViewController.m */,
+				F1737128184C2F5500422999 /* Images.xcassets */,
+				CEEF0E7A184EA3FE00B7DEDF /* RFMarkdownTextView */,
+				F173711D184C2F5500422999 /* Supporting Files */,
+			);
+			path = RFMarkdownTextViewDemo;
+			sourceTree = "<group>";
+		};
+		F173711D184C2F5500422999 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				F173711E184C2F5500422999 /* RFMarkdownTextViewDemo-Info.plist */,
+				F173711F184C2F5500422999 /* InfoPlist.strings */,
+				F1737122184C2F5500422999 /* main.m */,
+				F1737124184C2F5500422999 /* RFMarkdownTextViewDemo-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		F1737135184C2F5500422999 /* RFMarkdownTextViewDemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				F173713B184C2F5500422999 /* RFMarkdownTextViewDemoTests.m */,
+				F1737136184C2F5500422999 /* Supporting Files */,
+			);
+			path = RFMarkdownTextViewDemoTests;
+			sourceTree = "<group>";
+		};
+		F1737136184C2F5500422999 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				F1737137184C2F5500422999 /* RFMarkdownTextViewDemoTests-Info.plist */,
+				F1737138184C2F5500422999 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F1737112184C2F5500422999 /* RFMarkdownTextViewDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F173713F184C2F5500422999 /* Build configuration list for PBXNativeTarget "RFMarkdownTextViewDemo" */;
+			buildPhases = (
+				61255C9A23AF453BAD153CFC /* Check Pods Manifest.lock */,
+				F173710F184C2F5500422999 /* Sources */,
+				F1737110184C2F5500422999 /* Frameworks */,
+				F1737111184C2F5500422999 /* Resources */,
+				EFE0AE2605BA459980E4444B /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RFMarkdownTextViewDemo;
+			productName = RFMarkdownTextViewDemo;
+			productReference = F1737113184C2F5500422999 /* RFMarkdownTextViewDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F173712D184C2F5500422999 /* RFMarkdownTextViewDemoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F1737142184C2F5500422999 /* Build configuration list for PBXNativeTarget "RFMarkdownTextViewDemoTests" */;
+			buildPhases = (
+				F173712A184C2F5500422999 /* Sources */,
+				F173712B184C2F5500422999 /* Frameworks */,
+				F173712C184C2F5500422999 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F1737134184C2F5500422999 /* PBXTargetDependency */,
+			);
+			name = RFMarkdownTextViewDemoTests;
+			productName = RFMarkdownTextViewDemoTests;
+			productReference = F173712E184C2F5500422999 /* RFMarkdownTextViewDemoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F173710B184C2F5500422999 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = "Rex Finn";
+				TargetAttributes = {
+					F173712D184C2F5500422999 = {
+						TestTargetID = F1737112184C2F5500422999;
+					};
+				};
+			};
+			buildConfigurationList = F173710E184C2F5500422999 /* Build configuration list for PBXProject "RFMarkdownTextViewDemo" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = F173710A184C2F5500422999;
+			productRefGroup = F1737114184C2F5500422999 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F1737112184C2F5500422999 /* RFMarkdownTextViewDemo */,
+				F173712D184C2F5500422999 /* RFMarkdownTextViewDemoTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F1737111184C2F5500422999 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1737121184C2F5500422999 /* InfoPlist.strings in Resources */,
+				F1737129184C2F5500422999 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F173712C184C2F5500422999 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F173713A184C2F5500422999 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		61255C9A23AF453BAD153CFC /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		EFE0AE2605BA459980E4444B /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F173710F184C2F5500422999 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F1737147184C2F7600422999 /* ViewController.m in Sources */,
+				CE041EFF1852A74100F79297 /* RFMarkdownSyntaxStorage.m in Sources */,
+				F1737127184C2F5500422999 /* AppDelegate.m in Sources */,
+				CEEF0E7D184EA3FE00B7DEDF /* RFMarkdownTextView.m in Sources */,
+				F1737123184C2F5500422999 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F173712A184C2F5500422999 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F173713C184C2F5500422999 /* RFMarkdownTextViewDemoTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F1737134184C2F5500422999 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F1737112184C2F5500422999 /* RFMarkdownTextViewDemo */;
+			targetProxy = F1737133184C2F5500422999 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		F173711F184C2F5500422999 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F1737120184C2F5500422999 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		F1737138184C2F5500422999 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F1737139184C2F5500422999 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		F173713D184C2F5500422999 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/Pods";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		F173713E184C2F5500422999 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/Pods";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F1737140184C2F5500422999 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 140D57BB1EFCDC96C2A35264 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch";
+				INFOPLIST_FILE = "RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		F1737141184C2F5500422999 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 862CD844BB180D8F81485001 /* Pods.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch";
+				INFOPLIST_FILE = "RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		F1737143184C2F5500422999 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RFMarkdownTextViewDemo.app/RFMarkdownTextViewDemo";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "RFMarkdownTextViewDemoTests/RFMarkdownTextViewDemoTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		F1737144184C2F5500422999 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RFMarkdownTextViewDemo.app/RFMarkdownTextViewDemo";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "RFMarkdownTextViewDemo/RFMarkdownTextViewDemo-Prefix.pch";
+				INFOPLIST_FILE = "RFMarkdownTextViewDemoTests/RFMarkdownTextViewDemoTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F173710E184C2F5500422999 /* Build configuration list for PBXProject "RFMarkdownTextViewDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F173713D184C2F5500422999 /* Debug */,
+				F173713E184C2F5500422999 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F173713F184C2F5500422999 /* Build configuration list for PBXNativeTarget "RFMarkdownTextViewDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1737140184C2F5500422999 /* Debug */,
+				F1737141184C2F5500422999 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F1737142184C2F5500422999 /* Build configuration list for PBXNativeTarget "RFMarkdownTextViewDemoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1737143184C2F5500422999 /* Debug */,
+				F1737144184C2F5500422999 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F173710B184C2F5500422999 /* Project object */;
+}

--- a/RFMarkdownTextViewDemo/RFMarkdownTextViewDemo.xcodeproj/xcshareddata/xcschemes/RFMarkdownTextViewDemo.xcscheme
+++ b/RFMarkdownTextViewDemo/RFMarkdownTextViewDemo.xcodeproj/xcshareddata/xcschemes/RFMarkdownTextViewDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -72,7 +72,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F1737112184C2F5500422999"
@@ -90,7 +91,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F1737112184C2F5500422999"


### PR DESCRIPTION
- Fixed crashing when the text view's contents is set programmatically.
- Applied the MIT license to source files
- Use the system font's size as a base for the text view's font
  - next-up is to respond to text style changes
- Cache regex objects to improve performance a bit
